### PR TITLE
Configurable timeout

### DIFF
--- a/djamazing/settings.py
+++ b/djamazing/settings.py
@@ -1,0 +1,6 @@
+import datetime
+
+
+DEFAULT_SETTINGS = {
+    'SIGNATURE_TIMEOUT': datetime.timedelta(seconds=1.5)
+}

--- a/djamazing/urls.py
+++ b/djamazing/urls.py
@@ -5,5 +5,5 @@ from djamazing.views import FileView
 app_name = 'djamazing'
 
 urlpatterns = [
-    url(r'^(?P<filename>[\w+\/\.]+)/', FileView.as_view(), name='protected_file')
+    url(r'', FileView.as_view(), name='protected_file'),
 ]

--- a/djamazing/views.py
+++ b/djamazing/views.py
@@ -14,9 +14,11 @@ class FileView(View):
         else:
             self.storage = storage()
 
-    def get(self, request, filename):
+    def get(self, request):
         username = request.user.get_username()
+        filename = request.GET['filename']
         signature = request.GET['signature']
+
         if not check_signature(signature, filename, username):
             return HttpResponseForbidden()
         return HttpResponseRedirect(


### PR DESCRIPTION
* The CF timeout is configurable via settings
* There is a default settings file that sets timeout to 1.5s
* Filename is now sent by querystring instead of path to avoid encoding
  isues